### PR TITLE
Added mappings in list_updater.lua

### DIFF
--- a/lua/pieces/list_updater.lua
+++ b/lua/pieces/list_updater.lua
@@ -90,11 +90,15 @@ function ListUpdater:setup_keymaps()
     local keymaps = {
         ["<Up>"] = function() self:up_keymap() end,
         ["<Down>"] = function() self:down_keymap() end,
+        ["<C-k>"] = function() self:up_keymap() end,
+        ["<C-j>"] = function() self:down_keymap() end,
         ["<esc>"] = function() self.results_popup:unmount() end,
+        ["<C-c>"] = function() self.results_popup:unmount() end,
         ["<enter>"] = function() self.enter_keymap(self.items[self.current_index]) end,
         ["<Del>"] = function() self.delete_keymap(self.items[self.current_index]) end,
         ["<kDel>"] = function() self.delete_keymap(self.items[self.current_index]) end,
-        ["<BS>"] = function() self.delete_keymap(self.items[self.current_index]) end
+        ["<BS>"] = function() self.delete_keymap(self.items[self.current_index]) end,
+        ["<C-d>"] = function() self.delete_keymap(self.items[self.current_index]) end
     }
     local modes = { "i", "n" }
 


### PR DESCRIPTION
**Summary**: This PR introduces new key mappings for the ListUpdater feature. It includes custom functions to handle navigation, selection, and deletion of list items using keyboard shortcuts.

**Changes**:
Replaced key mappings:
- `<C-j>`/`<C-k>` for navigating up and down the list.
- `<C-d>` to delete the current item.
- `<C-c>` to close the results popup.
